### PR TITLE
Fixes for Evaluator Camera Type, Thermal Model Config, and Field Initialization

### DIFF
--- a/thermo_nerf/evaluator/evaluator.py
+++ b/thermo_nerf/evaluator/evaluator.py
@@ -64,6 +64,10 @@ class Evaluator:
             camera_ray_bundle,
             batch,
         ) in datamanager.fixed_indices_eval_dataloader:
+            # Generate camera indices based on the number of camera_to_worlds
+            camera_indices = torch.arange(camera_ray_bundle.camera_to_worlds.shape[0])
+            camera_ray_bundle = camera_ray_bundle.generate_rays(camera_indices)
+            
             outputs = self._pipeline.model.get_outputs_for_camera_ray_bundle(
                 camera_ray_bundle
             )

--- a/thermo_nerf/rgb_concat/concat_field.py
+++ b/thermo_nerf/rgb_concat/concat_field.py
@@ -5,6 +5,8 @@ from nerfstudio.field_components.spatial_distortions import SpatialDistortion
 from nerfstudio.fields.nerfacto_field import NerfactoField
 from torch import Tensor, nn
 
+from typing import Optional
+
 
 class ConcatNerfactoTField(NerfactoField):
     def __init__(
@@ -31,7 +33,7 @@ class ConcatNerfactoTField(NerfactoField):
         pass_semantic_gradients: bool = False,
         use_pred_normals: bool = False,
         use_average_appearance_embedding: bool = False,
-        spatial_distortion: SpatialDistortion | None = None,
+         spatial_distortion: Optional[SpatialDistortion] = None,
         implementation: Literal["tcnn", "torch"] = "tcnn",
     ) -> None:
         super().__init__(

--- a/thermo_nerf/rgb_concat/rgbt_renderer.py
+++ b/thermo_nerf/rgb_concat/rgbt_renderer.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, Union, Optional
 
 import nerfacc
 import torch
@@ -11,7 +11,7 @@ BackgroundColor = Union[
     Float[Tensor, "3"],
     Float[Tensor, "*bs 3"],
 ]
-BACKGROUND_COLOR_OVERRIDE: Float[Tensor, "3"] | None = None
+BACKGROUND_COLOR_OVERRIDE: Optional[Float[Tensor, "3"]] = None
 
 
 class RGBTRenderer(nn.Module):
@@ -30,8 +30,10 @@ class RGBTRenderer(nn.Module):
         rgb: Float[Tensor, "*bs num_samples 3"],
         weights: Float[Tensor, "*bs num_samples 1"],
         background_color: BackgroundColor = "random",
-        ray_indices: Int[Tensor, "num_samples"] | None = None,
-        num_rays: int | None = None,
+#         ray_indices: Optional[Int[Tensor, "num_samples"]] = None,
+#         num_rays: Optional[int] = None,
+        ray_indices: Optional[Int[Tensor, "num_samples"]] = None,
+        num_rays: Optional[int] = None
     ) -> Float[Tensor, "*bs 3"]:
         """Composite samples along ray and render color image.
         If background color is random, no BG color is added - as if the background
@@ -140,9 +142,12 @@ class RGBTRenderer(nn.Module):
         self,
         rgb: Float[Tensor, "*bs num_samples 3"],
         weights: Float[Tensor, "*bs num_samples 1"],
-        ray_indices: Int[Tensor, "num_samples"] | None = None,
-        num_rays: int | None = None,
-        background_color: BackgroundColor | None = None,
+#         ray_indices: Int[Tensor, "num_samples"] | None = None,
+#         num_rays: int | None = None,
+#         background_color: BackgroundColor | None = None,
+        ray_indices: Optional[Int[Tensor, "num_samples"]] = None,
+        num_rays: Optional[int] = None,
+        background_color: Optional[BackgroundColor] = None,
     ) -> Float[Tensor, "*bs 3"]:
         """Composite samples along ray and render color image
 

--- a/thermo_nerf/thermal_nerf/thermal_field.py
+++ b/thermo_nerf/thermal_nerf/thermal_field.py
@@ -83,6 +83,7 @@ class ThermalNerfactoTField(NerfactoField):
             use_pred_normals,
             use_average_appearance_embedding,
             spatial_distortion,
+            1.0,
             implementation,
         )
 

--- a/thermo_nerf/thermal_nerf/thermal_field.py
+++ b/thermo_nerf/thermal_nerf/thermal_field.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional, Dict, Union
 
 import torch
 from nerfstudio.cameras.rays import RaySamples
@@ -18,7 +18,7 @@ from thermo_nerf.thermal_nerf.thermal_field_head import (
 class ThermalFieldHead(BaseThermalFieldHead):
     """Thermal output"""
 
-    def __init__(self, in_dim: int | None = None) -> None:
+    def __init__(self, in_dim: Optional[int] = None) -> None:
         """`in_dim` is the input dimension. If not defined in the constructor,
         it must be set later.
         """
@@ -55,7 +55,7 @@ class ThermalNerfactoTField(NerfactoField):
         pass_semantic_gradients: bool = False,
         use_pred_normals: bool = False,
         use_average_appearance_embedding: bool = False,
-        spatial_distortion: SpatialDistortion | None = None,
+        spatial_distortion: Optional[SpatialDistortion] = None,
         implementation: Literal["tcnn", "torch"] = "tcnn",
         pass_thermal_gradients: bool = False,
     ) -> None:
@@ -106,8 +106,8 @@ class ThermalNerfactoTField(NerfactoField):
         self.pass_rgb_gradients = True
 
     def get_outputs(
-        self, ray_samples: RaySamples, density_embedding: Tensor | None = None
-    ) -> dict[FieldHeadNamesT | FieldHeadNames, Tensor]:
+        self, ray_samples: RaySamples, density_embedding: Optional[Tensor] = None
+    ) -> Dict[Union[FieldHeadNamesT, FieldHeadNames], Tensor]:
         assert density_embedding is not None
 
         outputs = {}
@@ -182,7 +182,7 @@ class ThermalNerfactoTField(NerfactoField):
 
     def forward(
         self, ray_samples: RaySamples, compute_normals: bool = False
-    ) -> dict[FieldHeadNamesT | FieldHeadNames, Tensor]:
+    ) -> Dict[Union[FieldHeadNamesT, FieldHeadNames], Tensor]:
         if compute_normals:
             with torch.enable_grad():
                 density, density_embedding = self.get_density(ray_samples)

--- a/thermo_nerf/thermal_nerf/thermal_nerf_model.py
+++ b/thermo_nerf/thermal_nerf/thermal_nerf_model.py
@@ -60,6 +60,8 @@ class ThermalNerfModelConfig(NerfactoModelConfig):
     """Minimum temperature in the dataset."""
     threshold: float = 0.0
     """Threshold for the thermal images that separated foreground from background."""
+    cold: bool = False
+    """Flag to indicate if the dataset includes cold temperatures."""
 
 
 class ThermalNerfModel(NerfactoModel):


### PR DESCRIPTION
This pull request addresses three key issues identified in the codebase:

1. **Evaluator Camera Type Issue**
   - Identified and fixed an issue in `evaluator.py` where `camera_ray_bundle` was of type `Camera` instead of `RayBundle`.
   - Added code to generate camera indices and convert `camera_ray_bundle` to `RayBundle` using the `generate_rays` method.

2. **ThermalNerfModelConfig Cold Flag**
   - Fixed an issue where the 'cold' attribute was missing in `ThermalNerfModelConfig`, causing an `AttributeError`.
   - Added a new boolean flag `cold` to indicate if the dataset includes cold temperatures.

3. **ThermalNerfactoTField Initialization**
   - Fixed an issue with `ThermalNerfactoTField` initialization where `average_init_density` was incorrectly set to a string value 'tcnn' instead of a numeric value.
   - Corrected the `super().__init__` call in `ThermalNerfactoTField` to include the `average_init_density` parameter correctly.

These fixes improve the stability and correctness of the codebase, ensuring proper type handling and configuration management.
