### PR TITLE
Fixes for Evaluator Camera Type, Thermal Model Config, and Field Initialization

### DIFF
--- a/thermo_nerf/evaluator/evaluator.py
+++ b/thermo_nerf/evaluator/evaluator.py
@@ -66,10 +66,10 @@ class Evaluator:
         ) in datamanager.fixed_indices_eval_dataloader:
             # Generate camera indices based on the number of camera_to_worlds
             camera_indices = torch.arange(camera_ray_bundle.camera_to_worlds.shape[0])
-            camera_ray_bundle = camera_ray_bundle.generate_rays(camera_indices)
+            cameras = camera_ray_bundle.generate_rays(camera_indices)
             
             outputs = self._pipeline.model.get_outputs_for_camera_ray_bundle(
-                camera_ray_bundle
+                cameras
             )
             (
                 metrics_dict,

--- a/thermo_nerf/evaluator/evaluator.py
+++ b/thermo_nerf/evaluator/evaluator.py
@@ -64,6 +64,10 @@ class Evaluator:
             camera_ray_bundle,
             batch,
         ) in datamanager.fixed_indices_eval_dataloader:
+            # Generate camera indices based on the number of camera_to_worlds
+            camera_indices = torch.arange(camera_ray_bundle.camera_to_worlds.shape[0])
+            camera_ray_bundle = camera_ray_bundle.generate_rays(camera_indices)
+            
             outputs = self._pipeline.model.get_outputs_for_camera_ray_bundle(
                 camera_ray_bundle
             )

--- a/thermo_nerf/evaluator/evaluator.py
+++ b/thermo_nerf/evaluator/evaluator.py
@@ -67,7 +67,7 @@ class Evaluator:
             # Generate camera indices based on the number of camera_to_worlds
             camera_indices = torch.arange(cameras.camera_to_worlds.shape[0])
             camera_ray_bundle = cameras.generate_rays(camera_indices)
-            
+
             outputs = self._pipeline.model.get_outputs_for_camera_ray_bundle(
                 camera_ray_bundle
             )

--- a/thermo_nerf/evaluator/evaluator.py
+++ b/thermo_nerf/evaluator/evaluator.py
@@ -61,15 +61,15 @@ class Evaluator:
             self._evaluation_images[modality] = []
 
         for (
-            camera_ray_bundle,
+            cameras,
             batch,
         ) in datamanager.fixed_indices_eval_dataloader:
             # Generate camera indices based on the number of camera_to_worlds
-            camera_indices = torch.arange(camera_ray_bundle.camera_to_worlds.shape[0])
-            cameras = camera_ray_bundle.generate_rays(camera_indices)
+            camera_indices = torch.arange(cameras.camera_to_worlds.shape[0])
+            camera_ray_bundle = cameras.generate_rays(camera_indices)
             
             outputs = self._pipeline.model.get_outputs_for_camera_ray_bundle(
-                cameras
+                camera_ray_bundle
             )
             (
                 metrics_dict,

--- a/thermo_nerf/thermal_nerf/thermal_field.py
+++ b/thermo_nerf/thermal_nerf/thermal_field.py
@@ -83,6 +83,7 @@ class ThermalNerfactoTField(NerfactoField):
             use_pred_normals,
             use_average_appearance_embedding,
             spatial_distortion,
+            1.0,
             implementation,
         )
 

--- a/thermo_nerf/thermal_nerf/thermal_nerf_model.py
+++ b/thermo_nerf/thermal_nerf/thermal_nerf_model.py
@@ -63,6 +63,7 @@ class ThermalNerfModelConfig(NerfactoModelConfig):
     cold: bool = False
     """Flag to indicate if the dataset includes cold temperatures."""
 
+
 class ThermalNerfModel(NerfactoModel):
     """
     ThermalNerfModel extends NerfactoModel to support thermal images

--- a/thermo_nerf/thermal_nerf/thermal_nerf_model.py
+++ b/thermo_nerf/thermal_nerf/thermal_nerf_model.py
@@ -60,7 +60,8 @@ class ThermalNerfModelConfig(NerfactoModelConfig):
     """Minimum temperature in the dataset."""
     threshold: float = 0.0
     """Threshold for the thermal images that separated foreground from background."""
-
+    cold: bool = False
+    """Flag to indicate if the dataset includes cold temperatures."""
 
 class ThermalNerfModel(NerfactoModel):
     """


### PR DESCRIPTION
This pull request addresses three key issues identified in the codebase:

1. **Evaluator Camera Type Issue**
   - Identified and fixed an issue in `evaluator.py` where `camera_ray_bundle` was of type `Camera` instead of `RayBundle`.
   - Added code to generate camera indices and convert `camera_ray_bundle` to `RayBundle` using the `generate_rays` method.

2. **ThermalNerfModelConfig Cold Flag**
   - Fixed an issue where the 'cold' attribute was missing in `ThermalNerfModelConfig`, causing an `AttributeError`.
   - Added a new boolean flag `cold` to indicate if the dataset includes cold temperatures.

3. **ThermalNerfactoTField Initialization**
   - Fixed an issue with `ThermalNerfactoTField` initialization where `average_init_density` was incorrectly set to a string value 'tcnn' instead of a numeric value.
   - Corrected the `super().__init__` call in `ThermalNerfactoTField` to include the `average_init_density` parameter correctly.

These fixes improve the stability and correctness of the codebase, ensuring proper type handling and configuration management.
